### PR TITLE
Start property panel

### DIFF
--- a/Sources/arm/ui/TabMaterials.hx
+++ b/Sources/arm/ui/TabMaterials.hx
@@ -212,7 +212,7 @@ class TabMaterials {
 		}
 	}
 
-	static function updateMaterial() {
+	public static function updateMaterial() {
 		UIHeader.inst.headerHandle.redraws = 2;
 		UINodes.inst.hwnd.redraws = 2;
 		UINodes.inst.groupStack = [];

--- a/Sources/arm/ui/TabProperties.hx
+++ b/Sources/arm/ui/TabProperties.hx
@@ -1,0 +1,86 @@
+package arm.ui;
+
+import kha.Color;
+import zui.Zui;
+import zui.Id;
+import arm.node.MakeMaterial;
+import arm.util.RenderUtil;
+
+
+class TabProperties {
+
+	@:access(zui.Zui)
+	public static function draw() {
+		var ui = UISidebar.inst.ui;
+		if (ui.tab(UISidebar.inst.htab0, tr("Properties"))) {
+            ui.text(Context.material.canvas.name);
+			ui.separator(3, false);
+            
+			var nodes = Context.material.canvas.nodes;
+            for (node in nodes) {
+                if (node.type == "MATERIAL_INPUT") {
+                    for (n in 0...node.outputs.length) {
+                        ui.text(node.outputs[n].name);
+                        
+                        if (node.outputs[n].type == "RGBA") {
+                            var h = Id.handle().nest(n);
+                            var oldColor = Color.fromFloats(node.outputs[n].default_value[0],node.outputs[n].default_value[1],node.outputs[n].default_value[2]);
+                            h.color = oldColor;
+                            ui.text("", 0, h.color);
+                            if (ui.isHovered && ui.inputDown) {
+                                UIMenu.draw(function(ui) {
+                                    ui.fill(0, 0, ui._w / ui.ops.scaleFactor, ui.t.ELEMENT_H * 9, ui.t.SEPARATOR_COL);
+                                    ui.changed = false;
+                                    var color = zui.Ext.colorWheel(ui, h, false, null, 10 * ui.t.ELEMENT_H * ui.SCALE(), true);
+                                    if (ui.changed) UIMenu.keepOpen = true;
+
+                                    if (h.changed){
+                                        node.outputs[n].default_value = [h.color.R, h.color.G, h.color.B, h.color.A];
+                                        App.notifyOnNextFrame(function() {
+                                            UINodes.inst.canvasChanged();
+                                            TabMaterials.updateMaterial();
+                                            UISidebar.inst.hwnd0.redraws = 1;
+                                        });
+                                    }
+                                }, 10);
+                            }
+                        }
+                        else if (node.outputs[n].type == "VALUE") {
+                            var h = Id.handle().nest(n);
+                            h.value = node.outputs[n].default_value;
+                            var val = ui.slider(h,"",node.outputs[n].min,node.outputs[n].max);
+                            
+                            if (h.changed) {
+                                node.outputs[n].default_value = val;
+                                App.notifyOnNextFrame(function() {
+                                    UINodes.inst.canvasChanged();
+                                    TabMaterials.updateMaterial();
+                                });
+                            }
+                        }
+                        else if (node.outputs[n].type == "VECTOR") {
+                            var val = [0.0,0.0,0.0];
+                            var h1 = Id.handle().nest(n,{selected: node.outputs[n].default_value[0]});
+                            h1.value = node.outputs[n].default_value[0];
+                            val[0] = ui.slider(h1,"x",node.outputs[n].min,node.outputs[n].max);
+                            var h2 = Id.handle().nest(n,{selected: node.outputs[n].default_value[1]});
+                            h2.value = node.outputs[n].default_value[1];
+                            val[1] = ui.slider(h2,"y",node.outputs[n].min,node.outputs[n].max);
+                            var h3 = Id.handle().nest(n,{selected: node.outputs[n].default_value[2]});
+                            h3.value = node.outputs[n].default_value[2];
+                            val[2] = ui.slider(h3,"z",node.outputs[n].min,node.outputs[n].max);
+                            
+                            if (h1.changed || h2.changed || h3.changed) {
+                                node.outputs[n].default_value = val;
+                                App.notifyOnNextFrame(function() {
+                                    UINodes.inst.canvasChanged();
+                                    TabMaterials.updateMaterial();
+                                });
+                            }
+                        }
+                    }
+                } 
+            }
+		}
+	}
+}

--- a/Sources/arm/ui/TabProperties.hx
+++ b/Sources/arm/ui/TabProperties.hx
@@ -20,13 +20,15 @@ class TabProperties {
             for (node in nodes) {
                 if (node.type == "MATERIAL_INPUT") {
                     for (n in 0...node.outputs.length) {
-                        ui.text(node.outputs[n].name);
                         
                         if (node.outputs[n].type == "RGBA") {
                             var h = Id.handle().nest(n);
                             var oldColor = Color.fromFloats(node.outputs[n].default_value[0],node.outputs[n].default_value[1],node.outputs[n].default_value[2]);
                             h.color = oldColor;
+                            ui.row([1/3, 2/3]);
+                            ui.text(node.outputs[n].name);
                             ui.text("", 0, h.color);
+                            
                             if (ui.isHovered && ui.inputDown) {
                                 UIMenu.draw(function(ui) {
                                     ui.fill(0, 0, ui._w / ui.ops.scaleFactor, ui.t.ELEMENT_H * 9, ui.t.SEPARATOR_COL);
@@ -48,7 +50,7 @@ class TabProperties {
                         else if (node.outputs[n].type == "VALUE") {
                             var h = Id.handle().nest(n);
                             h.value = node.outputs[n].default_value;
-                            var val = ui.slider(h,"",node.outputs[n].min,node.outputs[n].max);
+                            var val = ui.slider(h,node.outputs[n].name,node.outputs[n].min,node.outputs[n].max, true,100.0,true, Align.Left);
                             
                             if (h.changed) {
                                 node.outputs[n].default_value = val;
@@ -59,16 +61,17 @@ class TabProperties {
                             }
                         }
                         else if (node.outputs[n].type == "VECTOR") {
+                            ui.text(node.outputs[n].name);
                             var val = [0.0,0.0,0.0];
                             var h1 = Id.handle().nest(n,{selected: node.outputs[n].default_value[0]});
                             h1.value = node.outputs[n].default_value[0];
-                            val[0] = ui.slider(h1,"x",node.outputs[n].min,node.outputs[n].max);
+                            val[0] = ui.slider(h1,"x",node.outputs[n].min,node.outputs[n].max, true, 100.0, true, Align.Left);
                             var h2 = Id.handle().nest(n,{selected: node.outputs[n].default_value[1]});
                             h2.value = node.outputs[n].default_value[1];
-                            val[1] = ui.slider(h2,"y",node.outputs[n].min,node.outputs[n].max);
+                            val[1] = ui.slider(h2,"y",node.outputs[n].min,node.outputs[n].max, true, 100.0, true, Align.Left);
                             var h3 = Id.handle().nest(n,{selected: node.outputs[n].default_value[2]});
                             h3.value = node.outputs[n].default_value[2];
-                            val[2] = ui.slider(h3,"z",node.outputs[n].min,node.outputs[n].max);
+                            val[2] = ui.slider(h3,"z",node.outputs[n].min,node.outputs[n].max, true, 100.0, true, Align.Left);
                             
                             if (h1.changed || h2.changed || h3.changed) {
                                 node.outputs[n].default_value = val;
@@ -78,9 +81,11 @@ class TabProperties {
                                 });
                             }
                         }
+                        ui.separator(5, false);
                     }
                 } 
             }
+
 		}
 	}
 }

--- a/Sources/arm/ui/UINodes.hx
+++ b/Sources/arm/ui/UINodes.hx
@@ -125,7 +125,7 @@ class UINodes {
 		var canvas = getCanvas(true);
 		var node = nodes.getNode(canvas.nodes, socket.node_id);
 		if (ui.inputReleasedR) {
-			if (node.type == "GROUP_INPUT" || node.type == "GROUP_OUTPUT") {
+			if (node.type == "GROUP_INPUT" || node.type == "GROUP_OUTPUT" || node.type == "MATERIAL_INPUT") {
 				App.notifyOnNextFrame(function() {
 					arm.ui.UIMenu.draw(function(ui: Zui) {
 						ui.text(tr("Socket"), Right, ui.t.HIGHLIGHT_COL);
@@ -187,7 +187,10 @@ class UINodes {
 											socket.max = max;
 											socket.default_value = default_value;
 											UIBox.show = false;
-											NodesMaterial.syncSockets(node);
+											if (node.type != "MATERIAL_INPUT")
+												NodesMaterial.syncSockets(node);
+											else
+												UISidebar.inst.hwnd0.redraws = 2;
 											hwnd.redraws = 2;
 										}
 									}

--- a/Sources/arm/ui/UISidebar.hx
+++ b/Sources/arm/ui/UISidebar.hx
@@ -748,6 +748,7 @@ class UISidebar {
 		tabx = System.windowWidth() - Config.raw.layout[LayoutSidebarW];
 		if (ui.window(hwnd0, tabx, 0, Config.raw.layout[LayoutSidebarW], Config.raw.layout[LayoutSidebarH0])) {
 			TabLayers.draw();
+			TabProperties.draw();
 			TabHistory.draw();
 			TabPlugins.draw();
 		}


### PR DESCRIPTION
I implemented a short proof of concept for https://github.com/armory3d/armorpaint/issues/1289
The main idea is to reduce the need to use nodes. While nodes are a very flexible tool to create materials they are harder to use while texturing. 
My vision is that the nodes are used to build new (parametric) materials that can be customized by parameters while texturing.
Examples:
1. Edge wear applied as a fill layer 
![grafik](https://user-images.githubusercontent.com/28649121/163717602-39fa5ba7-31d6-4bec-beff-bee98cf33f6b.png)
2. Generic metal material that can be customized by setting the metal color or some surface pattern. 
![grafik](https://user-images.githubusercontent.com/28649121/163718273-2c331d77-7ed2-4e69-8de2-cb233f8dcca6.png)
3. Material templates for specific art styles like "blocky materials" (minecraft-style) 
![grafik](https://user-images.githubusercontent.com/28649121/163717878-6fb19482-d5ef-42db-8034-96716f744b89.png) Currently no textures can be selected in the panel but suppose it would be possible.

The concept has multiple benefits imho
1. It is easier to play around with materials.
2. There can be templates to adapt to a certain situation without having to dig in the node graph, without the need to understand the parameters and so on. The cloud could contain such materials.
3. It is much easier to use on tablets because the user can focus on the viewport without the need to share the space with the node editor.

Current Limitations:
1. Only one set of parameters per material. While this makes sense while painting it would make sense for fill layers to adjust the parameters on a fill layer basis. Node groups have this property because they can be instantiated in multiple materials. This property is of high value.
2. The panel position is not the final one. It might be a good idea to bring back thethird tab view on the right sidebar.
5. No textures. For me this is a must have feature. The best way is to extend the RGBA type to allow textures, too. I'm a bit unsure how to implement it though. First idea: the same way as it is done for image nodes. The input node would get an input slot for texture coordinates. Second idea: give the image node an input slot that sets the texture. I believe my first idea is better while the second one would be more flexible. In any case the functionality would also enhance node groups as well.
6. Parameters like the operation in math nodes can not be customized that way. By using "Values" as boolean-switches it is easy to work around most of these situations. 
7. The properties panel is not updated when the current material is renamed or a different material is selected
8. No direct compatibility with layer or mask node. It would be super cool to be able to access the mask(s) of a layer in this way.
9. It might be useful to add a button to the panel to create a new material with these special parameters to save it for later use in the project. 
10. Tooltips to explain the parameters could be useful, too.

Please do not merge yet, looking for your feedback first. It definitely needs polishing. Any feedback so far? Interested in this approach?

