### PR TITLE
Texture preview for browser

### DIFF
--- a/armorpaint/Sources/arm/ui/UIFiles.hx
+++ b/armorpaint/Sources/arm/ui/UIFiles.hx
@@ -253,6 +253,42 @@ class UIFiles {
 					}
 				}
 
+				if (Path.isTexture(f) && !isCloud) {
+					var w = 50;
+					if (iconMap == null) iconMap = [];
+					icon = iconMap.get(handle.text + Path.sep + f);
+					if (icon == null) {
+						var empty = iron.RenderPath.active.renderTargets.get("empty_black").image;
+						iconMap.set(handle.text + Path.sep + f, empty);
+						kha.Assets.loadImageFromPath(handle.text + Path.sep + f, false, function(image: kha.Image) {
+							iron.App.notifyOnInit(function() {
+								if (Layers.pipeCopyRGB == null) Layers.makePipeCopyRGB();
+								var sw = image.width > image.height ? w : Std.int(1.0 * image.width / image.height * w);
+								var sh = image.width > image.height ? Std.int(1.0 * image.height / image.width * w) : w;
+								icon = kha.Image.createRenderTarget(sw, sh);
+								icon.g2.begin(true, 0xffffffff);
+								icon.g2.pipeline = Layers.pipeCopyRGB;
+								icon.g2.drawScaledImage(image, 0, 0, sw, sh);
+								icon.g2.pipeline = null;
+								icon.g2.end();
+								iconMap.set(handle.text + Path.sep + f, icon);
+								UIStatus.inst.statusHandle.redraws = 3;
+								image.unload(); // The big image is not needed anymore
+							});
+						});
+					}
+					if (icon != null) {
+						if (i == selected) {
+							ui.fill(-2,        -2, w + 4,     2, ui.t.HIGHLIGHT_COL);
+							ui.fill(-2,     w + 2, w + 4,     2, ui.t.HIGHLIGHT_COL);
+							ui.fill(-2,         0,     2, w + 4, ui.t.HIGHLIGHT_COL);
+							ui.fill(w + 2 ,    -2,     2, w + 6, ui.t.HIGHLIGHT_COL);
+						}
+						state = ui.image(icon, 0xffffffff, icon.height * ui.SCALE());
+						generic = false;
+					}
+				}
+
 				if (generic) {
 					state = ui.image(icons, col, 50 * ui.SCALE(), rect.x, rect.y, rect.w, rect.h);
 				}


### PR DESCRIPTION
Currently ArmorPaint's browser has no thumbnails for textures (see https://github.com/armory3d/armortools/issues/814). This PR implements a starter for this feature.

Limitations:

1. The `iconMap` is not "garbage collected". But the very same holds for the cloud, too.
2. The numbnails have a fixed resolution independent of the ui scale. Implementing this feature would require to regenerate/delete the thumbails if the ui scale is changed.
