### PR TITLE
Add context menu to browser

### DIFF
--- a/armorpaint/Sources/arm/ui/UIFiles.hx
+++ b/armorpaint/Sources/arm/ui/UIFiles.hx
@@ -82,7 +82,7 @@ class UIFiles {
 
 	@:access(zui.Zui)
 	@:access(arm.sys.File)
-	public static function fileBrowser(ui: Zui, handle: Handle, foldersOnly = false, dragFiles = false, search = "", refresh = false): String {
+	public static function fileBrowser(ui: Zui, handle: Handle, foldersOnly = false, dragFiles = false, search = "", refresh = false, contextMenu : String -> Void = null): String {
 
 		var icons = Res.get("icons.k");
 		var folder = Res.tile50(icons, 2, 1);
@@ -255,6 +255,10 @@ class UIFiles {
 
 				if (generic) {
 					state = ui.image(icons, col, 50 * ui.SCALE(), rect.x, rect.y, rect.w, rect.h);
+				}
+
+				if (ui.isHovered && ui.inputReleasedR && contextMenu != null) {
+					contextMenu(handle.text + Path.sep + f);
 				}
 
 				if (state == Started) {


### PR DESCRIPTION
I added a context menu as suggested in https://github.com/armory3d/armortools/issues/814

The context menu differs by file type. Currently the only cases are texture or non-texture. 

- In the texture case some convenience functions are added to the context menu similar to the textures tab.
- The context menu is particularly useful for folders. Right click + import on a folder to import the content of a folder as new material (just as it is the case for drag and drop with folders)