### PR TITLE
Polish nodes

### DIFF
--- a/base/Sources/arm/shader/MaterialParser.hx
+++ b/base/Sources/arm/shader/MaterialParser.hx
@@ -685,6 +685,14 @@ class MaterialParser {
 			var col = parse_vector_input(node.inputs[1]);
 			return '(floor(100.0 * $strength * $col) / (100.0 * $strength))';
 		}
+		else if (node.type == "REPLACECOL") {
+			var inputColor = parse_vector_input(node.inputs[0]);
+			var oldColor = parse_vector_input(node.inputs[1]);
+			var newColor = parse_vector_input(node.inputs[2]);
+			var radius = parse_value_input(node.inputs[3]);
+			var fuzziness = parse_value_input(node.inputs[4]);
+			return 'mix($newColor, $inputColor, clamp((distance($oldColor, $inputColor) - $radius) / max($fuzziness, $eps), 0.0, 1.0))';
+		}
 		else if (node.type == "VALTORGB") { // ColorRamp
 			var fac = parse_value_input(node.inputs[0]);
 			var interp = node.buttons[0].data == 0 ? "LINEAR" : "CONSTANT";

--- a/base/Sources/arm/shader/NodesMaterial.hx
+++ b/base/Sources/arm/shader/NodesMaterial.hx
@@ -1758,6 +1758,7 @@ class NodesMaterial {
 					},
 					{
 						name: _tr("use_clamp"),
+						tooltip: _tr("Clamps the output value to the interval [0,1]."),
 						type: "BOOL",
 						default_value: false,
 						output: 0
@@ -1767,6 +1768,7 @@ class NodesMaterial {
 			{
 				id: 0,
 				name: _tr("Quantize"),
+				tooltip: _tr("Creates a posterization effect."),
 				type: "QUANTIZE",
 				x: 0,
 				y: 0,
@@ -1924,6 +1926,7 @@ class NodesMaterial {
 			{
 				id: 0,
 				name: _tr("Bump"),
+				tooltip: _tr("Generates a normal map from a height texture."),
 				type: "BUMP",
 				x: 0,
 				y: 0,
@@ -1941,6 +1944,7 @@ class NodesMaterial {
 						id: 0,
 						node_id: 0,
 						name: _tr("Distance"),
+						tooltip: _tr("Currently not implemented."),
 						type: "VALUE",
 						color: 0xffa1a1a1,
 						default_value: 0.0
@@ -1949,6 +1953,7 @@ class NodesMaterial {
 						id: 0,
 						node_id: 0,
 						name: _tr("Height"),
+						tooltip: _tr("Scalar value-typically a height map texture-giving the height offset from the surface."),
 						type: "VALUE",
 						color: 0xffa1a1a1,
 						default_value: 1.0
@@ -1977,6 +1982,7 @@ class NodesMaterial {
 			{
 				id: 0,
 				name: _tr("Mapping"),
+				tooltip: _tr("Transforms the input vector by applying translation, rotation, and scaling."),
 				type: "MAPPING",
 				x: 0,
 				y: 0,
@@ -2069,6 +2075,7 @@ class NodesMaterial {
 				buttons: [
 					{
 						name: _tr("blend_type"),
+						tooltip: _tr("Blending method"),
 						type: "ENUM",
 						data: [_tr("Partial Derivative"), _tr("Whiteout"), _tr("Reoriented")],
 						default_value: 0,
@@ -2209,6 +2216,7 @@ class NodesMaterial {
 			{
 				id: 0,
 				name: _tr("Clamp"),
+				tooltip: _tr("Clamps a value between a minimum and a maximum."),
 				type: "CLAMP",
 				x: 0,
 				y: 0,
@@ -2308,6 +2316,7 @@ class NodesMaterial {
 			{
 				id: 0,
 				name: _tr("Color Mask"),
+				tooltip: _tr("Generates a mask from color values-typically a texture-equal to mask color."),
 				type: "COLMASK",
 				x: 0,
 				y: 0,
@@ -2325,6 +2334,7 @@ class NodesMaterial {
 						id: 0,
 						node_id: 0,
 						name: _tr("Mask Color"),
+						tooltip: _tr("Color to use for mask."),
 						type: "RGBA",
 						color: 0xffc7c729,
 						default_value: f32([0.8, 0.8, 0.8, 1.0])
@@ -2333,6 +2343,7 @@ class NodesMaterial {
 						id: 0,
 						node_id: 0,
 						name: _tr("Radius"),
+						tooltip: _tr("Select colors within this range from input Mask Color."),
 						type: "VALUE",
 						color: 0xffa1a1a1,
 						default_value: 0.1,
@@ -2343,6 +2354,7 @@ class NodesMaterial {
 						id: 0,
 						node_id: 0,
 						name: _tr("Fuzziness"),
+						tooltip: _tr("Feather edges around selection. Higher values result in a softer mask."),
 						type: "VALUE",
 						color: 0xffa1a1a1,
 						default_value: 0.0
@@ -2557,6 +2569,7 @@ class NodesMaterial {
 				buttons: [
 					{
 						name: _tr("use_clamp"),
+						tooltip: _tr("Clamps the output value to the interval [0,1]."),
 						type: "BOOL",
 						default_value: false,
 						output: 0
@@ -2608,6 +2621,7 @@ class NodesMaterial {
 					},
 					{
 						name: _tr("use_clamp"),
+						tooltip: _tr("Clamps the output value to the interval [0,1]."),
 						type: "BOOL",
 						default_value: false,
 						output: 0

--- a/base/Sources/arm/shader/NodesMaterial.hx
+++ b/base/Sources/arm/shader/NodesMaterial.hx
@@ -1805,6 +1805,73 @@ class NodesMaterial {
 			},
 			{
 				id: 0,
+				name: _tr("Replace Color"),
+				type: "REPLACECOL",
+				x: 0,
+				y: 0,
+				color: 0xff62676d,
+				inputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Color"),
+						type: "RGBA",
+						color: 0xffc7c729,
+						default_value: f32([0.8, 0.8, 0.8, 1.0])
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Old Color"),
+						tooltip: _tr("Color to replace."),
+						type: "RGBA",
+						color: 0xffc7c729,
+						default_value: f32([0.8, 0.8, 0.8, 1.0])
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("New Color"),
+						tooltip: _tr("The replacement color."),
+						type: "RGBA",
+						color: 0xffc7c729,
+						default_value: f32([0.8, 0.8, 0.8, 1.0])
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Radius"),
+						tooltip: _tr("Replace colors within this range."),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.1,
+						min: 0.0,
+						max: 1.74
+					},
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Fuzziness"),
+						tooltip: _tr("Soften edges around replaced regions."),
+						type: "VALUE",
+						color: 0xffa1a1a1,
+						default_value: 0.0
+					}
+				],
+				outputs: [
+					{
+						id: 0,
+						node_id: 0,
+						name: _tr("Color"),
+						type: "RGBA",
+						color: 0xffc7c729,
+						default_value: f32([0.8, 0.8, 0.8, 1.0])
+					}
+				],
+				buttons: []
+			},
+			{
+				id: 0,
 				name: _tr("Warp"),
 				type: "DIRECT_WARP", // extension
 				x: 0,


### PR DESCRIPTION
I tried in increase ArmorPaint's usability. This PR implements two things.

1. A new "Replace Color" node. It does exactly what it sounds like

![grafik](https://user-images.githubusercontent.com/28649121/225658848-a589acc2-ae7e-403d-a1ca-43c96872795e.png)
is changed to
![grafik](https://user-images.githubusercontent.com/28649121/225658984-913f9725-855c-49f7-9de8-fbffc31e6635.png)
by these nodes
![grafik](https://user-images.githubusercontent.com/28649121/225659121-4f065027-bd2b-4dbf-96c0-c6782bf9adb7.png)

The fuzziness is to create softer regions:
![grafik](https://user-images.githubusercontent.com/28649121/225659713-eaab6283-90b2-4f9b-bc6c-0950f9cf4a69.png)
![grafik](https://user-images.githubusercontent.com/28649121/225659855-09cbcbfb-f41a-49b4-80cc-9f11fac7629c.png)
made by:
![grafik](https://user-images.githubusercontent.com/28649121/225659943-95112883-a4e6-4a60-a2fb-869da8ecc020.png)

In theory this result could be achieved with a combination of MixRGB and Color Mask but I believe this to be way more intuitive and replacing a color is a relatively frequent operation.

2. I started adding some tooltips to nodes I believe are harder to use. Most are relatively straight forward, but the 'Bump' node isn't for example. Implements: https://github.com/armory3d/armortools/issues/927 In case you dislike the wording, feel free to give me an example and I'll try to adapt the others. In case you find other hard to use nodes, feel free to list them and I will add further tooltips.