### PR TITLE
Drop material and swatches at position in layers

### DIFF
--- a/armorpaint/Sources/arm/ui/TabLayers.hx
+++ b/armorpaint/Sources/arm/ui/TabLayers.hx
@@ -221,6 +221,18 @@ class TabLayers {
 				}
 			}
 		}
+		if (App.isDragging && (App.dragMaterial != null || App.dragSwatch != null) && Context.inLayers()) {
+			if (mouse.y > ui._y + step && mouse.y < ui._y + step * 3) {
+				Context.raw.dragDestination = i;
+				if (canDropNewLayer(i))
+					ui.fill(checkw, 2 * step, (ui._windowW / ui.SCALE() - 2) - checkw, 2 * ui.SCALE(), ui.t.HIGHLIGHT_COL);
+			}
+			else if (i == Project.layers.length - 1 && mouse.y < ui._y + step) {
+				Context.raw.dragDestination = Project.layers.length;
+				if (canDropNewLayer(Project.layers.length))
+					ui.fill(checkw, 0, (ui._windowW / ui.SCALE() - 2) - checkw, 2 * ui.SCALE(), ui.t.HIGHLIGHT_COL);
+			}
+		}
 
 		var hasPanel = l.isGroup() || (l.isLayer() && l.getMasks(false) != null);
 		if (hasPanel) {
@@ -882,5 +894,14 @@ class TabLayers {
 
 		// Do not delete last layer
 		return numLayers > 1;
+	}
+
+	public static function canDropNewLayer(position: Int) {
+		if (position > 0 && position < Project.layers.length && Project.layers[position - 1].isMask()) {
+			// 1. The layer to insert is inserted in the middle
+			// 2. The layer below is a mask, i.e. the layer would have to be a (group) mask, too.
+			return false;
+		}
+		return true;
 	}
 }


### PR DESCRIPTION
This PR implements a drag and drop system for materials and swatches in the layer stack similar to reordering layers via drag and drop. 
![grafik](https://user-images.githubusercontent.com/28649121/225870800-c7f4f08c-4663-4724-98ca-cfc95baa7ea1.png)

I think that's cool 😎 and more intuitive than the previous system.
Drop in viewport is not changed.

Resolves https://github.com/armory3d/armortools/issues/1014
