### PR TITLE
Make node search case insensitive

### DIFF
--- a/armorpaint/Sources/arm/ui/UINodes.hx
+++ b/armorpaint/Sources/arm/ui/UINodes.hx
@@ -466,7 +466,7 @@ class UINodes {
 		var first = true;
 		UIMenu.draw(function(ui: Zui) {
 			ui.fill(0, 0, ui._w / ui.SCALE(), ui.t.ELEMENT_H * 8, ui.t.SEPARATOR_COL);
-			var search = ui.textInput(searchHandle, "", Left, true, true);
+			var search = ui.textInput(searchHandle, "", Left, true, true).toLowerCase();
 			ui.changed = false;
 			if (first) {
 				first = false;


### PR DESCRIPTION
I made the node search case insensitive. Now this works:
![grafik](https://user-images.githubusercontent.com/28649121/225879377-a74a059c-6f53-4a97-a66d-2b2eb96849cb.png)
Previously nothing was found.