### PR TITLE
Fixes compile error for Metal

### DIFF
--- a/base/Sources/Main.hx
+++ b/base/Sources/Main.hx
@@ -147,7 +147,7 @@ class Main {
 		}
 	}
 
-	#if (kha_direct3d12 || kha_vulkan)
+	#if (kha_direct3d12 || kha_vulkan || kha_metal)
 
 	public static function embedRaytrace() {
 		var global = js.Syntax.code("globalThis");


### PR DESCRIPTION
Fixes compile error for Metal by enabling function definitions for `kha_metal` flag
Error was:
```
base/Sources/Main.hx:35: characters 3-16 : Unknown identifier : embedRaytrace
base/Sources/Main.hx:37: characters 3-20 : Unknown identifier : embedRaytraceBake
```