### PR TITLE
Update actions/checkout to v3

### DIFF
--- a/.github/workflows/android_opengl.yml
+++ b/.github/workflows/android_opengl.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get Submodules
       run: git submodule update --init --recursive
     - name: Compile

--- a/.github/workflows/ios_metal.yml
+++ b/.github/workflows/ios_metal.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get Submodules
       run: git submodule update --init --recursive
     - name: Compile

--- a/.github/workflows/linux_vulkan.yml
+++ b/.github/workflows/linux_vulkan.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Apt Update
       run: sudo apt-get update
     - name: Apt Install

--- a/.github/workflows/macos_metal.yml
+++ b/.github/workflows/macos_metal.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get Submodules
       run: git submodule update --init --recursive
     - name: Compile

--- a/.github/workflows/windows_direct3d12.yml
+++ b/.github/workflows/windows_direct3d12.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get Submodules
       run: git submodule update --init --recursive
     - name: Compile


### PR DESCRIPTION
Fix warning in with current action:
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

```