### PR TITLE
Fixed Bug - Build Error for ArmorForge

### DIFF
--- a/armorforge/sources/sim.ts
+++ b/armorforge/sources/sim.ts
@@ -9,8 +9,6 @@ function sim_init() {
 
 function sim_update() {
 
-	render_path_raytrace_ready = false;
-
     if (sim_running) {
         // if (render_path_raytrace_frame != 1) {
             // return;


### PR DESCRIPTION
### Resolving the "undeclared identifier 'render_path_raytrace_ready'" Error When Building Armorforge

When attempting to build the Armorforge tool, the following error may occur:

![Screenshot 2024-12-12 095837](https://github.com/user-attachments/assets/97583e50-120f-46f7-b6f6-ee4838bc1d0c)

This issue arises because the variable `render_path_raytrace_ready` is not properly declared in the code. Two approaches are available to resolve this error and complete the build process successfully.

---

### **Method 1: Declare the Variable in `iron.c`**

1. **Locate the `iron.c` File**:
    
    The `iron.c` file is generated during the build process using the command:
    ```
    ..\armorcore\make --graphics direct3d11
    ```
    This command is typically executed within the `\armortools\armorforge` folder.
    
2. **Identify the Error Location**:
    
    The **Error List** in the IDE can be used to locate the specific error message:
    
    `use of undeclared identifier 'render_path_raytrace_ready'`.
    
    Double-clicking on the error will navigate directly to line **39456** in the `iron.c` file where the issue is located.

    
![Screenshot 2024-12-12 065131](https://github.com/user-attachments/assets/0f1bbc30-c818-44b8-963c-7838de873f2e)
    
3. **Modify the Code**:
    
    The `render_path_raytrace_ready` variable must be declared as a boolean. The following adjustment should be made in the code:
    
    - Before:
        
        ```csharp
        render_path_raytrace_ready = false;
        ```
        
    - After:
        
        ```csharp
        bool render_path_raytrace_ready = false;
        ```
        
4. **Save and Rebuild**:
    
    After saving the changes to the `iron.c` file, the solution file can be rebuilt in Visual Studio. This ensures that the variable is properly declared and eliminates the error.

    
![Screenshot 2024-12-12 065257](https://github.com/user-attachments/assets/97aaccc9-2dea-48f6-b5b2-9bf421667c37)

---

### **Method 2: Remove the Variable from `sim.ts`**

1. **Locate the `sim.ts` File**:
    
    The `sim.ts` file contains an unnecessary or redundant declaration of the `render_path_raytrace_ready` variable.
    
2. **Identify and Remove the Variable**:
    
    The declaration of `render_path_raytrace_ready` is found on **line 12** of the `sim.ts` file. This line should be commented out or removed:
    
    ```csharp
    render_path_raytrace_ready = false;
    ```
    
3. **Save and build**:
    
    Once the changes to the `sim.ts` file is saved, this will fix the issue and no issues will occur with the build process for Armorforge.
    
    
![Screenshot 2024-12-12 101200](https://github.com/user-attachments/assets/25e25ddf-9f76-4b1d-b7fc-383e9a404a63)


---

### Summary

Both methods provide a solution to the undeclared identifier error. Method 1 involves declaring the variable correctly, while Method 2 involves commenting out or removing the unnecessary variable declaration. Once the appropriate adjustments are made and the solution is rebuilt in Visual Studio, the build process for Armorforge will complete successfully.