### PR TITLE
Fix NAN definition in some environments

### DIFF
--- a/armorcore/sources/libs/quickjs/quickjs.h
+++ b/armorcore/sources/libs/quickjs/quickjs.h
@@ -32,6 +32,9 @@
 #include <string.h>
 #include <math.h>
 
+#undefine NAN
+#define NAN (__builtin_nanf(""))
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Usage of non-builtin NAN can trigger error:
"Initializer element is not a compile-time constant"

This happened to me with current code, compiled it on latest toolsets over windows 11
Basically the `quickjs.c` is using the `NAN` which is normally a function, as a compile-time constant

The bigger fix is to take the updated QuickJS engine from: https://github.com/quickjs-ng/quickjs

There is another option of using `(double)0x7FF8000000000000` manually,
but I opted against anything that relies on magic-numbers that can be per-toolset