### PR TITLE
Info on running ArmorPaint.exe outside of Visual Studio

### DIFF
--- a/armorpaint/readme.md
+++ b/armorpaint/readme.md
@@ -19,6 +19,8 @@ cd armortools/armorpaint
 ..\armorcore\make --graphics direct3d11
 # Open generated Visual Studio project at `build\ArmorPaint.sln`
 # Build and run
+# To launch ArmorPaint.exe outside of Visual Studio:
+# Copy file `build\x64\Release\ArmorPaint.exe` and place it in folder `build\out\`
 ```
 
 **Linux (x64)**


### PR DESCRIPTION
Added next text:
```
# To launch ArmorPaint.exe outside of Visual Studio:
# Copy file `build\x64\Release\ArmorPaint.exe` and place it in folder `build\out\`
```