### PR TITLE
Fix the Windows CI by actually calling 'vcvarsall.bat x64'

### DIFF
--- a/.github/workflows/windows_direct3d12.yml
+++ b/.github/workflows/windows_direct3d12.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Compile
+      shell: cmd
       run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
         cd armorpaint
         ../base/make --graphics direct3d12 --compile


### PR DESCRIPTION
The Windows CI doesn't run properly because 'vcvarsall.bat x64' is not called prior to try building the project which causes MSBuild to not be found