### PR TITLE
Allow importing *.gltf files with additional binary data

### DIFF
--- a/armorpaint/assets/plugins/import_gltf_glb.js
+++ b/armorpaint/assets/plugins/import_gltf_glb.js
@@ -2,7 +2,7 @@
 function import_gltf_glb(path) {
 	let b = data_get_blob(path);
 	data_delete_blob(path);
-	return io_gltf_parse(b);
+	return io_gltf_parse(b, path);
 }
 
 let plugin = plugin_create();

--- a/armorpaint/plugins/plugins.c
+++ b/armorpaint/plugins/plugins.c
@@ -23,11 +23,12 @@ FN(io_usd_parse) {
 	return JS_NewInt64(ctx, (int64_t)io_usd_parse(ab, len));
 }
 
-void *io_gltf_parse(char *buf, size_t size);
+void *io_gltf_parse(char *buf, size_t size, const char *path);
 FN(io_gltf_parse) {
 	size_t len;
 	void *ab = JS_GetArrayBuffer(ctx, &len, argv[0]);
-	return JS_NewInt64(ctx, (int64_t)io_gltf_parse(ab, len));
+	const char *path = JS_ToCString(ctx, argv[1]);
+	return JS_NewInt64(ctx, (int64_t)io_gltf_parse(ab, len, path));
 }
 
 void *io_fbx_parse(char *buf, size_t size);
@@ -43,7 +44,7 @@ void plugin_embed() {
 	BIND(proc_xatlas_unwrap, 1);
 	BIND(io_svg_parse, 1);
 	BIND(io_usd_parse, 1);
-	BIND(io_gltf_parse, 1);
+	BIND(io_gltf_parse, 2);
 	BIND(io_fbx_parse, 1);
 
 	JS_FreeValue(js_ctx, global_obj);


### PR DESCRIPTION
This PR adds a _path_ argument to `io_gltf_parse` to ensure *.gltf files with additional, external *.bin files are loaded, which was required for my pipeline. I also encountered some meshes with null primitives, so the code has been modified to instead search for the first initialised primitive in the mesh and load that. The vertex count is now also explicitly set based on the positions buffer.

I understand there may be some interactions that I didn't forsee with other platforms and the like (such as using different forms of IO where `cgltf` may not be able to search the filesystem for binary files), let me know and I am willing to fix these up as necessary.